### PR TITLE
Remove dependency on log4net [breaking change]

### DIFF
--- a/Pat.Sender.Log4Net/LogicalThreadContextCorrelationIdProvider.cs
+++ b/Pat.Sender.Log4Net/LogicalThreadContextCorrelationIdProvider.cs
@@ -1,6 +1,7 @@
 ﻿using log4net;
+using Pat.Sender.Correlation;
 
-namespace Pat.Sender.Correlation
+namespace Pat.Sender.Log4Net
 {
     public class LogicalThreadContextCorrelationIdProvider : ICorrelationIdProvider
     {

--- a/Pat.Sender.Log4Net/Pat.Sender.Log4Net.csproj
+++ b/Pat.Sender.Log4Net/Pat.Sender.Log4Net.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>0.0.0</Version>
+    <Authors>Pat.Sender</Authors>
+    <Company>Purplebricks</Company>
+    <Product>Pat.Sender</Product>
+    <Description>Log4Net logging adapter for Purplebricks message sending infrastructure</Description>
+    <PackageLicenseUrl>https://github.com/purplebricks/Pat.Sender/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>http://purplebricks.io/pat/</PackageProjectUrl>
+    <PackageIconUrl>https://pbonlineassets.azureedge.net/web-images/favicons/favicon-96x96.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/purplebricks/Pat.Sender</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pat.Sender\Pat.Sender.csproj" />
+    <PackageReference Include="log4net" Version="2.0.8" />
+  </ItemGroup>
+
+</Project>

--- a/Pat.Sender.Log4Net/PatSenderLog4NetAdapter.cs
+++ b/Pat.Sender.Log4Net/PatSenderLog4NetAdapter.cs
@@ -1,0 +1,27 @@
+﻿using log4net;
+using System;
+
+namespace Pat.Sender.Log4Net
+{
+    public class PatSenderLog4NetAdapter : IPatSenderLog
+    {
+        private readonly ILog log;
+
+        public PatSenderLog4NetAdapter(ILog log)
+        {
+            this.log = log;
+        }
+
+        public void LogCritical(string message, params object[] arguments)
+            => log.FatalFormat(message, arguments);
+
+        public void LogInformation(string message)
+            => log.Info(message);
+
+        public void LogWarning(string message)
+            => log.Warn(message);
+
+        public void LogWarning(string message, Exception exception)
+            => log.Warn(message, exception);
+    }
+}

--- a/Pat.Sender.NetCoreLog/Pat.Sender.NetCoreLog.csproj
+++ b/Pat.Sender.NetCoreLog/Pat.Sender.NetCoreLog.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>0.0.0</Version>
+    <Authors>Pat.Sender</Authors>
+    <Company>Purplebricks</Company>
+    <Product>Pat.Sender</Product>
+    <Description>.NET Core logging adapter for Purplebricks message sending infrastructure</Description>
+    <PackageLicenseUrl>https://github.com/purplebricks/Pat.Sender/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>http://purplebricks.io/pat/</PackageProjectUrl>
+    <PackageIconUrl>https://pbonlineassets.azureedge.net/web-images/favicons/favicon-96x96.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/purplebricks/Pat.Sender</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pat.Sender\Pat.Sender.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Pat.Sender.NetCoreLog/PatSenderNetCoreLogAdapter.cs
+++ b/Pat.Sender.NetCoreLog/PatSenderNetCoreLogAdapter.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+
+namespace Pat.Sender.NetCoreLog
+{
+    public class PatSenderNetCoreLogAdapter : IPatSenderLog
+    {
+        private readonly ILogger log;
+
+        public PatSenderNetCoreLogAdapter(ILogger log)
+        {
+            this.log = log;
+        }
+
+        public void LogCritical(string message, params object[] arguments)
+            => log.LogCritical(message, arguments);
+
+        public void LogInformation(string message)
+            => log.LogInformation(message);
+
+        public void LogWarning(string message)
+            => log.LogWarning(message);
+
+        public void LogWarning(string message, Exception exception)
+            => log.LogWarning(exception, message);
+    }
+}

--- a/Pat.Sender.sln
+++ b/Pat.Sender.sln
@@ -7,6 +7,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pat.Sender", "Pat.Sender\Pa
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pat.Sender.UnitTests", "Pat.Sender.UnitTests\Pat.Sender.UnitTests.csproj", "{C8E86715-05A3-492F-AA96-7D41973D528D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pat.Sender.Log4Net", "Pat.Sender.Log4Net\Pat.Sender.Log4Net.csproj", "{52B6CC38-AD74-44B7-AB45-60833348C826}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pat.Sender.NetCoreLog", "Pat.Sender.NetCoreLog\Pat.Sender.NetCoreLog.csproj", "{086427A3-F905-48E7-BDB2-4E4E943B231F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +25,14 @@ Global
 		{C8E86715-05A3-492F-AA96-7D41973D528D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8E86715-05A3-492F-AA96-7D41973D528D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8E86715-05A3-492F-AA96-7D41973D528D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52B6CC38-AD74-44B7-AB45-60833348C826}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52B6CC38-AD74-44B7-AB45-60833348C826}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52B6CC38-AD74-44B7-AB45-60833348C826}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52B6CC38-AD74-44B7-AB45-60833348C826}.Release|Any CPU.Build.0 = Release|Any CPU
+		{086427A3-F905-48E7-BDB2-4E4E943B231F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{086427A3-F905-48E7-BDB2-4E4E943B231F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{086427A3-F905-48E7-BDB2-4E4E943B231F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{086427A3-F905-48E7-BDB2-4E4E943B231F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Pat.Sender/IPatSenderLog.cs
+++ b/Pat.Sender/IPatSenderLog.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Pat.Sender
+{
+    // Remove this when net451 support is dropped, using Microsoft.Extensions.Logging.Abstractions types instead.
+    // Also then remove the package Pat.Sender.NetCoreLog and *consider* removing Pat.Sender.Log4Net
+    public interface IPatSenderLog
+    {
+        void LogInformation(string message);
+        void LogWarning(string message);
+        void LogWarning(string message, Exception exception);
+        void LogCritical(string message, params object[] arguments);
+    }
+}

--- a/Pat.Sender/Pat.Sender.csproj
+++ b/Pat.Sender/Pat.Sender.csproj
@@ -14,7 +14,6 @@
     <RepositoryUrl>https://github.com/purplebricks/Pat.Sender</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
   </ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.0.{build}
+version: 3.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 branches:


### PR DESCRIPTION
Add support for both log4net and .NET Core Logging.  When Support for .NET 4.5.1 can be dropped then the customer IPatSenderLog interface can be removed and MS's .NET Core abstraction can be used instead.  This removes the need for consuming projects to reference log4net.